### PR TITLE
feat(models): add registry and fetcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ __pycache__/
 work/
 output/
 logs/
-models/
+models/*
+!models/registry.json
 assets/

--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 
 License: MIT
 
-本仓库提供**分轨 → 主人声 → 去混响+降噪 → RVC → 每轨处理 → 总线 → 质检**的**独立 CLI 契约**与编排脚手架。当前为**占位实现**：
-- 不包含重型音频算法与外部模型；
-- CLI 可运行、可解析参数、会输出 sidecar JSON 与占位产物；
-- 目录/文件/字段/退出码等契约已固定，后续只需填充真实实现。
+本仓库提供**分轨 → 主人声 → 去混响+降噪 → RVC → 每轨处理 → 总线 → 质检**的**独立 CLI 契约**与编排脚手架。默认实现仍为占位逻辑，但新增了**模型获取器**以自动拉取公共模型。
+您可以在 `models/registry.json` 中查看注册表并通过 `python -m bin.model_fetcher` 将所需模型下载到本地。
 
 ## 快速使用
 ```bash
@@ -15,6 +13,11 @@ chmod +x scripts/run_pipeline.sh
 ./scripts/run_pipeline.sh MySong
 # 或
 python scripts/run_pipeline.py MySong
+```
+
+首次运行前可执行模型获取：
+```bash
+python -m bin.model_fetcher
 ```
 
 ## Dry Run
@@ -32,6 +35,7 @@ python -m bin.env_probe --dry-run
 * `scripts/run_pipeline.sh`：顺序编排执行。
 * `scripts/run_pipeline.py`：跨平台编排器。
 * `Makefile`：常用目标。
+* `env/requirements-full.txt`：全量依赖列表。
 
 ## 契约
 

--- a/bin/model_fetcher.py
+++ b/bin/model_fetcher.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+import argparse, json, os, sys, shutil, pathlib
+from typing import List, Dict, Any
+from . import _utils as u
+
+STAGE = '00-model_fetcher'
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+REGISTRY_DEFAULT = ROOT / 'models' / 'registry.json'
+
+
+def parse_hf_source(src: str):
+    spec = src[3:]
+    if ':' in spec:
+        repo, rest = spec.split(':', 1)
+    else:
+        repo, rest = spec, ''
+    revision = None
+    filename = rest
+    if rest.startswith('resolve/'):
+        _, revision, filename = rest.split('/', 2)
+    return repo, filename, revision
+
+
+def download_hf(src: str, dest: pathlib.Path):
+    from huggingface_hub import hf_hub_download
+    repo, filename, revision = parse_hf_source(src)
+    tmp = hf_hub_download(repo_id=repo, filename=filename, revision=revision)
+    os.makedirs(dest.parent, exist_ok=True)
+    shutil.copyfile(tmp, dest)
+
+
+def fetch_files(items: List[Dict[str, Any]], force: bool, missing: List[Dict[str, str]]):
+    for it in items:
+        dest = ROOT / it['path']
+        if dest.exists() and not force:
+            continue
+        try:
+            src = it['source']
+            if src.startswith('hf:'):
+                download_hf(src, dest)
+            else:
+                raise RuntimeError(f'Unsupported source {src}')
+            if it.get('sha256'):
+                if u.sha256_file(str(dest)) != it['sha256']:
+                    raise RuntimeError('sha256 mismatch')
+        except Exception as e:
+            missing.append({'file': it['path'], 'error': str(e)})
+
+
+def fetch_demucs(models: List[str], missing: List[Dict[str, str]]):
+    try:
+        import demucs.pretrained
+        for m in models:
+            try:
+                demucs.pretrained.get_model(m)
+            except Exception as e:
+                missing.append({'demucs_model': m, 'error': str(e)})
+    except Exception as e:
+        missing.append({'provider': 'demucs', 'error': str(e)})
+
+
+def build_plan(registry: Dict[str, Any]) -> List[str]:
+    plan = []
+    for sec in registry.values():
+        if sec.get('files'):
+            for it in sec['files']:
+                plan.append(str(ROOT / it['path']))
+        if sec.get('provider') == 'pip-demucs':
+            for m in sec.get('models', []):
+                plan.append(f'demucs:{m}')
+    return plan
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    u.add_common_args(ap)
+    ap.add_argument('--registry', default=str(REGISTRY_DEFAULT))
+    ap.add_argument('--force', action='store_true')
+    args = ap.parse_args()
+    reg_path = pathlib.Path(args.registry)
+    with open(reg_path, 'r', encoding='utf-8') as f:
+        registry = json.load(f)
+    plan = build_plan(registry)
+    if args.dry_run:
+        print(json.dumps({'stage': STAGE, 'plan_outputs': plan}, ensure_ascii=False, indent=2))
+        return 0
+    missing: List[Dict[str, str]] = []
+    for name, sec in registry.items():
+        if sec.get('provider') == 'pip-demucs':
+            fetch_demucs(sec.get('models', []), missing)
+        if sec.get('files'):
+            fetch_files(sec['files'], args.force, missing)
+    if missing:
+        miss_path = ROOT / 'missing_models.json'
+        with open(miss_path, 'w', encoding='utf-8') as f:
+            json.dump({'missing': missing}, f, ensure_ascii=False, indent=2)
+        u.emit_log(args.log_json, {'stage': STAGE, 'missing': missing})
+        return 22
+    u.emit_log(args.log_json, {'stage': STAGE, 'status': 'ok'})
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/env/requirements-full.txt
+++ b/env/requirements-full.txt
@@ -1,0 +1,31 @@
+# Core
+numpy>=1.26
+scipy>=1.11
+librosa>=0.10
+soundfile>=0.12
+PyYAML>=6.0
+jsonschema>=4.21
+rich>=13.0
+ tqdm>=4.66
+
+# DSP & IO
+ffmpeg-python>=0.2
+pydub>=0.25
+pyloudnorm>=0.1.1
+
+# Separation
+torch>=2.1
+ torchaudio>=2.1
+ demucs>=4.0.0
+
+# Dereverb / Denoise
+nara-wpe>=0.0.7
+ deepfilternet>=0.5.6
+
+# RVC
+fairseq>=0.12.2
+ faiss-cpu>=1.7.4
+ huggingface_hub>=0.23
+ onnxruntime>=1.16
+ numba>=0.58
+ llvmlite>=0.41

--- a/models/registry.json
+++ b/models/registry.json
@@ -1,0 +1,22 @@
+{
+  "demucs": {
+    "provider": "pip-demucs",
+    "models": ["htdemucs_ft"]
+  },
+  "hubert": {
+    "files": [
+      {"path": "models/hubert/hubert_base.pt", "source": "hf:facebook/hubert-base:resolve/main/hubert.pt", "sha256": null}
+    ]
+  },
+  "f0": {
+    "files": [
+      {"path": "models/f0/rmvpe.pt", "source": "hf:lj1995/VoiceConversionWebUI:resolve/main/assets/rmvpe.pt", "sha256": null},
+      {"path": "models/f0/fcpe.pt",  "source": "hf:FishAudio/FCPE:resolve/main/fcpe.pt", "sha256": null}
+    ]
+  },
+  "dfn": {
+    "files": [
+      {"path": "models/dfn/DeepFilterNet3/model", "source": "hf:Rikorose/DeepFilterNet:resolve/main/DeepFilterNet3/model", "sha256": null}
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add model registry and fetcher utility
- document model fetching and full dependency list

## Testing
- `python -m bin.model_fetcher --dry-run` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_689cf1c515848330bd898664e8398d3a