### PR TITLE
docs: refine project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,42 @@
 # Mix02 — 模块化音频管线（仓库脚手架｜可替换实现）
 
-License: MIT
+Mix02 是一个用于构建端到端音频处理流程的示例仓库。项目提供**分轨 → 主人声提取 → 去混响与降噪 → RVC 转换 → 每轨处理 → 总线混音 → 质检**的完整 CLI 契约。默认逻辑仍为占位实现，但接口与文件契约已经确定，可逐步替换为真实算法。
 
-本仓库提供**分轨 → 主人声 → 去混响+降噪 → RVC → 每轨处理 → 总线 → 质检**的**独立 CLI 契约**与编排脚手架。默认实现仍为占位逻辑，但新增了**模型获取器**以自动拉取公共模型。
-您可以在 `models/registry.json` 中查看注册表并通过 `python -m bin.model_fetcher` 将所需模型下载到本地。
+## 特性
+- **模块化 stage**：通过 `python -m bin.<stage>` 调用，每一步都可单独运行或替换。
+- **模型获取器**：使用 `bin.model_fetcher` 根据 `models/registry.json` 自动下载公共模型。
+- **多预设**：`presets` 提供 `best-quality`、`safe-vram`、`fast` 三种参数组合。
+- **dry-run 支持**：所有 CLI 支持 `--dry-run` 输出计划而不写文件。
 
-## 快速使用
+## 快速开始
 ```bash
 python -m venv .venv && source .venv/bin/activate
 pip install -e .[dev]
+python -m bin.model_fetcher  # 可选，首次运行前拉取模型
 chmod +x scripts/run_pipeline.sh
 ./scripts/run_pipeline.sh MySong
 # 或
 python scripts/run_pipeline.py MySong
 ```
 
-首次运行前可执行模型获取：
-```bash
-python -m bin.model_fetcher
-```
+## 项目结构
+| 目录 | 说明 |
+| --- | --- |
+| `bin/` | 各 stage 的 CLI 占位实现 |
+| `presets/` | 参数预设文件 |
+| `schemas/` | JSON Schema 定义 |
+| `scripts/` | 顺序或跨平台编排器 |
+| `docs/` | 项目说明与契约文档 |
+| `tests/` | 契约测试 |
 
-## Dry Run
+更多信息请参阅 [docs/README.md](docs/README.md) 与 [docs/CONTRACTS.md](docs/CONTRACTS.md)。
 
-所有 CLI 支持 `--dry-run` 查看计划而不写文件，例如：
-```bash
-python -m bin.env_probe --dry-run
-```
+## 契约摘要
+- 内部规格：48kHz / 32-bit float / stereo
+- 最终混音命名：`99_Final_<Song>_mix_24b48k.wav`
+- 质检报告：`QC.md`；运行留痕：`RUNLOG.json`
+- 退出码：0 / 1 / 12 / 22 / 32 / 42
+- sidecar 字段详见 `schemas/sidecar.schema.json`
 
-## 结构
-
-* `bin/*`：每个 stage 的 CLI（占位实现）。
-* `presets/*.yaml`：参数预设（best-quality / safe-vram / fast）。
-* `schemas/*.json`：sidecar 与 error 的 JSON Schema。
-* `scripts/run_pipeline.sh`：顺序编排执行。
-* `scripts/run_pipeline.py`：跨平台编排器。
-* `Makefile`：常用目标。
-* `env/requirements-full.txt`：全量依赖列表。
-
-## 契约
-
-* 内部规格：48k/32f/立体声；
-* 最终混音命名：`99_Final_<Song>_mix_24b48k.wav`；
-* 质检报告：`QC.md`，运行留痕：`RUNLOG.json`；
-* 退出码：0/1/12/22/32/42；
-* sidecar 字段：见 `schemas/sidecar.schema.json`。
-
-## 实现真实算法
-
-在保持**文件契约与参数接口不变**的前提下，逐步将 `bin/*` 中的占位逻辑替换为真实 DSP/推理即可。
+## 贡献与许可证
+欢迎提交 Issue 或 PR 来完善脚手架。项目采用 [MIT License](LICENSE)。

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# 项目说明
+
+Mix02 是一个模块化音频处理管线的脚手架，旨在演示基于 CLI 契约的阶段化处理流程。仓库提供了一套可以自由替换的占位实现，便于根据需求逐步替换为真实算法。
+
+## 核心特性
+- 分层 CLI 契约：每一步都可以单独调用或替换。
+- 自动模型获取器：根据 `models/registry.json` 下载公共模型。
+- 多预设：`presets` 内提供 best-quality / safe-vram / fast 预设。
+
+## 仓库结构
+- `bin/`：各阶段 CLI 占位实现。
+- `presets/*.yaml`：参数预设。
+- `schemas/*.json`：sidecar 与错误 Schema。
+- `scripts/`：跨平台编排器。
+- `tests/`：契约测试。
+
+更多契约细节见 [CONTRACTS.md](CONTRACTS.md)。


### PR DESCRIPTION
## Summary
- expand main README with features, quickstart, and project layout
- add project overview document under docs

## Testing
- `pytest` *(fails: No module named 'yaml')*
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_689d24ed9f248330af95f97ab9c8b4dd