### PR TITLE
Add Snakemake workflow and utility enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ chmod +x scripts/run_pipeline.sh
 python scripts/run_pipeline.py MySong
 ```
 
+### Snakemake 编排
+项目同时提供 Snakemake 工作流，便于并行与复现：
+
+```bash
+cd workflow
+snakemake --profile profiles/local --dry-run   # 预览 DAG
+```
+详见 `workflow/README-snakemake.md`。
+
 ## 项目结构
 | 目录 | 说明 |
 | --- | --- |

--- a/bin/_utils.py
+++ b/bin/_utils.py
@@ -1,16 +1,55 @@
 from __future__ import annotations
-import argparse, json, os, datetime, hashlib, pathlib, yaml
+import argparse, json, os, datetime, hashlib, pathlib, subprocess, shutil
+try:  # optional dependency
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - fallback when PyYAML absent
+    yaml = None
 
-def sha256_file(p: str) -> str:
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+def ensure_dir(p: str | os.PathLike) -> str:
+    """Create directory *p* if missing and return the path as string."""
+    os.makedirs(p, exist_ok=True)
+    return str(p)
+
+def run_cmd(cmd: list[str]) -> subprocess.CompletedProcess:
+    """Run a subprocess command and return the completed process."""
+    return subprocess.run(cmd, check=True, text=True, capture_output=True)
+
+def sha256sum(p: str) -> str:
     h = hashlib.sha256()
     with open(p, 'rb') as f:
-        for chunk in iter(lambda: f.read(1<<20), b''):
+        for chunk in iter(lambda: f.read(1 << 20), b''):
             h.update(chunk)
     return h.hexdigest()
 
+# backward compat
+sha256_file = sha256sum
+
+def write_json(path: str | os.PathLike, data: dict):
+    ensure_dir(os.path.dirname(path))
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+def dry_run_guard(args, plan: dict) -> bool:
+    """Print plan and return True if in dry-run mode."""
+    if getattr(args, 'dry_run', False):
+        print(json.dumps(plan, ensure_ascii=False, indent=2))
+        return True
+    return False
+
+def ffprobe_json(p: str) -> dict:
+    try:
+        proc = run_cmd(['ffprobe', '-v', 'quiet', '-print_format', 'json',
+                        '-show_format', '-show_streams', p])
+        return json.loads(proc.stdout)
+    except Exception:
+        return {}
+
 def load_preset(name: str) -> dict:
-    root = pathlib.Path(__file__).resolve().parents[1]
-    p = root / 'presets' / f'{name}.yaml'
+    p = ROOT / 'presets' / f'{name}.yaml'
+    if yaml is None:
+        return {}
     with open(p, 'r', encoding='utf-8') as f:
         return yaml.safe_load(f)
 
@@ -32,25 +71,32 @@ def parse_overrides(items: list[str]) -> dict:
             ov[k] = v
     return ov
 
-def sidecar(out_path: str, stage: str, preset: str, overrides: dict, inp: str|None):
+def sidecar(out_path: str, stage: str, preset: str, overrides: dict, inp: str | None):
     now = datetime.datetime.utcnow().isoformat() + 'Z'
     sc = {
         'input': os.path.abspath(inp) if inp else None,
         'output': os.path.abspath(out_path),
         'stage': stage,
-        'sha256': sha256_file(out_path) if os.path.exists(out_path) else None,
+        'sha256': sha256sum(out_path) if os.path.exists(out_path) else None,
         'samplerate': 48000,
         'bit_depth': 32,
         'channels': 2,
-        'metrics': {'peak_dbfs': None, 'integrated_lufs': None, 'true_peak_dbtp': None, 'duration_sec': None},
+        'metrics': {
+            'peak_dbfs': None,
+            'integrated_lufs': None,
+            'true_peak_dbtp': None,
+            'duration_sec': None
+        },
         'params': {'preset': preset, 'overrides': overrides},
         'timestamp': now,
         'status': 'ok'
     }
     return sc
 
-def emit_log(log_path: str|None, payload: dict):
-    if not log_path: return
-    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+def emit_log(log_path: str | None, payload: dict):
+    if not log_path:
+        return
+    ensure_dir(os.path.dirname(log_path))
     with open(log_path, 'a', encoding='utf-8') as f:
         f.write(json.dumps(payload, ensure_ascii=False) + '\n')
+

--- a/bin/env_probe.py
+++ b/bin/env_probe.py
@@ -1,8 +1,33 @@
 from __future__ import annotations
-import argparse, json, os, sys
+import argparse, json, os, sys, platform, shutil
 from . import _utils as u
 
 STAGE = '00-env_probe'
+
+def probe_env() -> dict:
+    info = {
+        'python': platform.python_version(),
+        'ffmpeg_version': None,
+        'cuda_available': False,
+        'torch_version': None,
+        'gpu': None,
+        'cpu_count': os.cpu_count(),
+        'disk_free_gb': shutil.disk_usage('.').free / 1e9,
+    }
+    try:
+        proc = u.run_cmd(['ffmpeg', '-version'])
+        info['ffmpeg_version'] = proc.stdout.splitlines()[0]
+    except Exception:
+        info['ffmpeg_version'] = None
+    try:
+        import torch
+        info['torch_version'] = torch.__version__
+        info['cuda_available'] = bool(torch.cuda.is_available())
+        if info['cuda_available']:
+            info['gpu'] = torch.cuda.get_device_name(0)
+    except Exception:
+        pass
+    return info
 
 def main():
     ap = argparse.ArgumentParser()
@@ -10,16 +35,15 @@ def main():
     args = ap.parse_args()
     u.load_preset(args.preset)
     ov = u.parse_overrides(args.override)
-    out_path = args.out or os.path.join(args.outdir, 'env.txt')
-    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    out_path = args.out or os.path.join(args.outdir, 'env.json')
+    u.ensure_dir(os.path.dirname(out_path))
     plan = {'stage': STAGE, 'plan_output': os.path.abspath(out_path)}
-    if args.dry_run:
-        print(json.dumps(plan, ensure_ascii=False, indent=2))
+    if u.dry_run_guard(args, plan):
         return 0
-    open(out_path, 'w', encoding='utf-8').write('env ok\n')
+    data = probe_env()
+    u.write_json(out_path, data)
     sc = u.sidecar(out_path, STAGE, args.preset, ov, args.inp)
-    with open(out_path + '.json', 'w', encoding='utf-8') as f:
-        json.dump(sc, f, ensure_ascii=False, indent=2)
+    u.write_json(out_path + '.json', sc)
     u.emit_log(args.log_json, {'stage': STAGE, 'output': out_path})
     return 0
 

--- a/bin/model_fetcher.py
+++ b/bin/model_fetcher.py
@@ -1,100 +1,63 @@
 from __future__ import annotations
-import argparse, json, os, sys, shutil, pathlib
-from typing import List, Dict, Any
+import argparse, json, os, sys, pathlib, urllib.request, shutil, hashlib
 from . import _utils as u
 
 STAGE = '00-model_fetcher'
-
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 REGISTRY_DEFAULT = ROOT / 'models' / 'registry.json'
 
 
-def parse_hf_source(src: str):
-    spec = src[3:]
-    if ':' in spec:
-        repo, rest = spec.split(':', 1)
-    else:
-        repo, rest = spec, ''
-    revision = None
-    filename = rest
-    if rest.startswith('resolve/'):
-        _, revision, filename = rest.split('/', 2)
-    return repo, filename, revision
+def download(url: str, dest: pathlib.Path):
+    with urllib.request.urlopen(url) as r, open(dest, 'wb') as f:
+        shutil.copyfileobj(r, f)
 
 
-def download_hf(src: str, dest: pathlib.Path):
-    from huggingface_hub import hf_hub_download
-    repo, filename, revision = parse_hf_source(src)
-    tmp = hf_hub_download(repo_id=repo, filename=filename, revision=revision)
-    os.makedirs(dest.parent, exist_ok=True)
-    shutil.copyfile(tmp, dest)
-
-
-def fetch_files(items: List[Dict[str, Any]], force: bool, missing: List[Dict[str, str]]):
-    for it in items:
-        dest = ROOT / it['path']
-        if dest.exists() and not force:
-            continue
+def fetch(entry: dict, force: bool) -> tuple[pathlib.Path, str | None]:
+    filename = os.path.basename(entry['urls'][0])
+    dest = ROOT / 'models' / filename
+    if dest.exists() and not force:
+        return dest, None
+    last_err: Exception | None = None
+    for url in entry['urls']:
         try:
-            src = it['source']
-            if src.startswith('hf:'):
-                download_hf(src, dest)
-            else:
-                raise RuntimeError(f'Unsupported source {src}')
-            if it.get('sha256'):
-                if u.sha256_file(str(dest)) != it['sha256']:
+            u.ensure_dir(dest.parent)
+            download(url, dest)
+            if entry.get('size') and dest.stat().st_size != entry['size']:
+                raise RuntimeError('size mismatch')
+            if entry.get('sha256'):
+                h = u.sha256sum(dest)
+                if h != entry['sha256']:
                     raise RuntimeError('sha256 mismatch')
-        except Exception as e:
-            missing.append({'file': it['path'], 'error': str(e)})
-
-
-def fetch_demucs(models: List[str], missing: List[Dict[str, str]]):
-    try:
-        import demucs.pretrained
-        for m in models:
-            try:
-                demucs.pretrained.get_model(m)
-            except Exception as e:
-                missing.append({'demucs_model': m, 'error': str(e)})
-    except Exception as e:
-        missing.append({'provider': 'demucs', 'error': str(e)})
-
-
-def build_plan(registry: Dict[str, Any]) -> List[str]:
-    plan = []
-    for sec in registry.values():
-        if sec.get('files'):
-            for it in sec['files']:
-                plan.append(str(ROOT / it['path']))
-        if sec.get('provider') == 'pip-demucs':
-            for m in sec.get('models', []):
-                plan.append(f'demucs:{m}')
-    return plan
+            return dest, None
+        except Exception as e:  # pragma: no cover - network failures
+            last_err = e
+            if dest.exists():
+                dest.unlink()
+    return dest, str(last_err) if last_err else 'unknown error'
 
 
 def main():
     ap = argparse.ArgumentParser()
     u.add_common_args(ap)
     ap.add_argument('--registry', default=str(REGISTRY_DEFAULT))
+    ap.add_argument('--name', nargs='*')
+    ap.add_argument('--all', action='store_true')
     ap.add_argument('--force', action='store_true')
     args = ap.parse_args()
-    reg_path = pathlib.Path(args.registry)
-    with open(reg_path, 'r', encoding='utf-8') as f:
-        registry = json.load(f)
-    plan = build_plan(registry)
-    if args.dry_run:
-        print(json.dumps({'stage': STAGE, 'plan_outputs': plan}, ensure_ascii=False, indent=2))
+    with open(args.registry, 'r', encoding='utf-8') as f:
+        reg_list = json.load(f)
+    registry = {it['name']: it for it in reg_list}
+    targets = list(registry.keys()) if args.all or not args.name else args.name
+    plan = [str(ROOT / 'models' / os.path.basename(registry[n]['urls'][0])) for n in targets]
+    if u.dry_run_guard(args, {'stage': STAGE, 'plan_outputs': plan}):
         return 0
-    missing: List[Dict[str, str]] = []
-    for name, sec in registry.items():
-        if sec.get('provider') == 'pip-demucs':
-            fetch_demucs(sec.get('models', []), missing)
-        if sec.get('files'):
-            fetch_files(sec['files'], args.force, missing)
+    missing = []
+    for n in targets:
+        dest, err = fetch(registry[n], args.force)
+        if err:
+            missing.append({'name': n, 'error': err})
     if missing:
-        miss_path = ROOT / 'missing_models.json'
-        with open(miss_path, 'w', encoding='utf-8') as f:
-            json.dump({'missing': missing}, f, ensure_ascii=False, indent=2)
+        u.write_json(ROOT / 'missing_models.json', {'missing': missing})
         u.emit_log(args.log_json, {'stage': STAGE, 'missing': missing})
         return 22
     u.emit_log(args.log_json, {'stage': STAGE, 'status': 'ok'})
@@ -103,3 +66,4 @@ def main():
 
 if __name__ == '__main__':
     sys.exit(main())
+

--- a/env/requirements-full.txt
+++ b/env/requirements-full.txt
@@ -6,7 +6,7 @@ soundfile>=0.12
 PyYAML>=6.0
 jsonschema>=4.21
 rich>=13.0
- tqdm>=4.66
+tqdm>=4.66
 
 # DSP & IO
 ffmpeg-python>=0.2
@@ -28,4 +28,5 @@ fairseq>=0.12.2
  huggingface_hub>=0.23
  onnxruntime>=1.16
  numba>=0.58
- llvmlite>=0.41
+llvmlite>=0.41
+snakemake>=7.32

--- a/models/registry.json
+++ b/models/registry.json
@@ -1,22 +1,39 @@
-{
-  "demucs": {
-    "provider": "pip-demucs",
-    "models": ["htdemucs_ft"]
+[
+  {
+    "name": "hubert-base",
+    "version": "1.0",
+    "urls": [
+      "https://huggingface.co/facebook/hubert-base/resolve/main/hubert.pt"
+    ],
+    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "size": 0
   },
-  "hubert": {
-    "files": [
-      {"path": "models/hubert/hubert_base.pt", "source": "hf:facebook/hubert-base:resolve/main/hubert.pt", "sha256": null}
-    ]
+  {
+    "name": "rmvpe",
+    "version": "1.0",
+    "urls": [
+      "https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/assets/rmvpe.pt"
+    ],
+    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "size": 0
   },
-  "f0": {
-    "files": [
-      {"path": "models/f0/rmvpe.pt", "source": "hf:lj1995/VoiceConversionWebUI:resolve/main/assets/rmvpe.pt", "sha256": null},
-      {"path": "models/f0/fcpe.pt",  "source": "hf:FishAudio/FCPE:resolve/main/fcpe.pt", "sha256": null}
-    ]
+  {
+    "name": "fcpe",
+    "version": "1.0",
+    "urls": [
+      "https://huggingface.co/FishAudio/FCPE/resolve/main/fcpe.pt"
+    ],
+    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "size": 0
   },
-  "dfn": {
-    "files": [
-      {"path": "models/dfn/DeepFilterNet3/model", "source": "hf:Rikorose/DeepFilterNet:resolve/main/DeepFilterNet3/model", "sha256": null}
-    ]
+  {
+    "name": "deepfilternet3",
+    "version": "3.x",
+    "urls": [
+      "https://huggingface.co/Rikorose/DeepFilterNet/resolve/main/DeepFilterNet3/model"
+    ],
+    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "size": 0
   }
-}
+]
+

--- a/workflow/README-snakemake.md
+++ b/workflow/README-snakemake.md
@@ -1,0 +1,14 @@
+# Snakemake Workflow
+
+此目录包含使用 Snakemake 实现的编排示例。默认配置在 `config/config.yaml`，
+本地 profile 位于 `profiles/local`。
+
+快速测试：
+
+```bash
+cd workflow
+snakemake --profile profiles/local --dry-run
+```
+
+运行上述命令将列出完整 DAG 与最终目标。
+

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,0 +1,131 @@
+workdir: ".."
+
+configfile: "config/config.yaml"
+
+songs = config["songs"]
+preset = config.get("preset", "best-quality")
+threads_default = config.get("resources", {}).get("threads", 1)
+
+rule all:
+    input:
+        expand("output/{song}/99_Final_{song}_mix_24b48k.wav", song=songs),
+        expand("output/{song}/QC.md", song=songs),
+        expand("output/{song}/RUNLOG.json", song=songs)
+
+rule env_probe:
+    output: "work/{song}/stage-00/env.json"
+    params: outdir="work/{song}/stage-00"
+    shell:
+        "python -m bin.env_probe --outdir {params.outdir}"
+
+rule prep_audio:
+    input: "input/{song}.wav"
+    output: "work/{song}/stage-05/master_48k32f.wav"
+    params:
+        outdir="work/{song}/stage-05",
+        preset=preset
+    shell:
+        "python -m bin.prep_audio --in {input} --outdir {params.outdir} --preset {params.preset}"
+
+rule separate_stems:
+    input: "work/{song}/stage-05/master_48k32f.wav"
+    output:
+        vocal="work/{song}/stage-10/Vocal.raw",
+        drums="work/{song}/stage-10/Drums.raw",
+        bass="work/{song}/stage-10/Bass.raw",
+        other="work/{song}/stage-10/Other.raw"
+    params:
+        outdir="work/{song}/stage-10"
+    threads: threads_default
+    shell:
+        "python -m bin.separate_stems --in {input} --outdir {params.outdir}"
+
+rule extract_lead:
+    input: "work/{song}/stage-10/Vocal.raw"
+    output: "work/{song}/stage-21/Lead.raw"
+    params: outdir="work/{song}/stage-21"
+    shell:
+        "python -m bin.extract_lead --in {input} --outdir {params.outdir}"
+
+rule dereverb_denoise:
+    input: "work/{song}/stage-21/Lead.raw"
+    output: "work/{song}/stage-25/Lead_DRY.raw"
+    params: outdir="work/{song}/stage-25"
+    shell:
+        "python -m bin.dereverb_denoise --in {input} --outdir {params.outdir}"
+
+# Optional build_rvc_index
+if config.get("rvc", {}).get("build_index", False):
+    rule build_rvc_index:
+        input: "work/{song}/stage-05/master_48k32f.wav"
+        output: "models/rvc/{song}.index"
+        params: outdir="models/rvc"
+        shell:
+            "python -m bin.build_rvc_index --in {input} --outdir {params.outdir}"
+
+rule rvc_convert:
+    input: "work/{song}/stage-25/Lead_DRY.raw"
+    output: "work/{song}/stage-35/Lead_RVC.raw"
+    params:
+        outdir="work/{song}/stage-35",
+        model=config.get("rvc", {}).get("model_path", "")
+    shell:
+        "python -m bin.rvc_convert --in {input} --outdir {params.outdir} --model {params.model}"
+
+rule track_chain_drums:
+    input: "work/{song}/stage-10/Drums.raw"
+    output: "work/{song}/stage-40/01_Drums_stem.wav"
+    params: outdir="work/{song}/stage-40"
+    shell:
+        "python -m bin.track_chain --in {input} --outdir {params.outdir}"
+
+rule track_chain_bass:
+    input: "work/{song}/stage-10/Bass.raw"
+    output: "work/{song}/stage-41/02_Bass_stem.wav"
+    params: outdir="work/{song}/stage-41"
+    shell:
+        "python -m bin.track_chain --in {input} --outdir {params.outdir}"
+
+rule track_chain_other:
+    input: "work/{song}/stage-10/Other.raw"
+    output: "work/{song}/stage-42/03_Other_stem.wav"
+    params: outdir="work/{song}/stage-42"
+    shell:
+        "python -m bin.track_chain --in {input} --outdir {params.outdir}"
+
+rule track_chain_lead:
+    input: "work/{song}/stage-35/Lead_RVC.raw"
+    output: "work/{song}/stage-43/04_Lead_RVC_processed.wav"
+    params: outdir="work/{song}/stage-43"
+    shell:
+        "python -m bin.track_chain --in {input} --outdir {params.outdir}"
+
+rule mix_bus:
+    input:
+        drums="work/{song}/stage-40/01_Drums_stem.wav",
+        bass="work/{song}/stage-41/02_Bass_stem.wav",
+        other="work/{song}/stage-42/03_Other_stem.wav",
+        lead="work/{song}/stage-43/04_Lead_RVC_processed.wav"
+    output: "output/{song}/99_Final_{song}_mix_24b48k.wav"
+    params: outdir="output/{song}"
+    shell:
+        "python -m bin.mix_bus --drums {input.drums} --bass {input.bass} --other {input.other} --lead {input.lead} --outdir {params.outdir}"
+
+rule qc_report:
+    input: "output/{song}/99_Final_{song}_mix_24b48k.wav"
+    output:
+        json="output/{song}/qc.json",
+        md="output/{song}/QC.md"
+    params: outdir="output/{song}"
+    shell:
+        "python -m bin.qc_report --in {input} --outdir {params.outdir}"
+
+rule finalize_run:
+    input:
+        mix="output/{song}/99_Final_{song}_mix_24b48k.wav",
+        qc="output/{song}/QC.md"
+    output: "output/{song}/RUNLOG.json"
+    params: outdir="output/{song}"
+    shell:
+        "python -m bin.finalize_run --song {wildcards.song} --outdir {params.outdir}"
+

--- a/workflow/config/config.yaml
+++ b/workflow/config/config.yaml
@@ -1,0 +1,7 @@
+songs: [MySong]
+preset: best-quality
+rvc:
+  enable: true
+  model_path: models/rvc/DUMMY.pth
+resources:
+  threads: 8

--- a/workflow/profiles/local/config.yaml
+++ b/workflow/profiles/local/config.yaml
@@ -1,0 +1,4 @@
+cores: 8
+keep-going: true
+rerun-incomplete: true
+printshellcmds: true


### PR DESCRIPTION
## Summary
- Introduce Snakemake workflow with configs and profile to orchestrate full audio pipeline
- Expand utility helpers and environment probe CLI for richer runtime info and dry-run support
- Add model registry and fetcher using simple URL-based downloads

## Testing
- `pytest -q`
- `python -m bin.env_probe --outdir work/Dry/stage-00 --dry-run`
- ⚠️ `snakemake --profile profiles/local --dry-run` *(failed: command not found / install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_689f954e44688330b9dc1a36e55c187f